### PR TITLE
decorate.js checks wrong rollcall nominate field to detect lopsided votes

### DIFF
--- a/static/js/decorate.js
+++ b/static/js/decorate.js
@@ -243,8 +243,8 @@ function decorateNominate(oc,data) {
         {
 		if(data.rollcalls != undefined)
 		{
-			var nomData = data.rollcalls[0].nominate;
-			if(nomData != undefined && nomData.pre != undefined)
+		        var nomData = data.rollcalls[0].nominate;
+			if(nomData != undefined && nomData.spread != undefined)
 			{
 				ggg.append('text').text("Lopsided vote with")
 					.attr("class","fitbox").attr("x", xAxisMax - 110)

--- a/static/js/decorate.js
+++ b/static/js/decorate.js
@@ -255,10 +255,13 @@ function decorateNominate(oc,data) {
 				var legendType=2;
 			}
 			else
-			{
-				ggg.append('text').text("NOMINATE not yet computed")
-					.attr("class","fitbox").attr("x", xAxisMax - 75)
-					.attr("y", yAxisMax - 25);
+		        {
+			        ggg.append('text').text("NOMINATE not")
+					.attr("class","fitbox").attr("x", xAxisMax - 110)
+					.attr("y", yAxisMax - 12);
+				ggg.append('text').text("yet estimated")
+					.attr("class","fitbox").attr("x", xAxisMax - 110)
+					.attr("y", yAxisMax - 0);
 				var legendType=3;
 			}
 	


### PR DESCRIPTION
Now it checks spread which is [0,0] if its lopsided and undefined if not estimated yet. Message on chart should be more appropriate now. Previously, it was saying "Lopsided vote" when nominate had not yet been estimated.